### PR TITLE
[fix] product status 오류 버그 수정.

### DIFF
--- a/src/main/java/org/mwt/market/domain/product/controller/ProductController.java
+++ b/src/main/java/org/mwt/market/domain/product/controller/ProductController.java
@@ -99,7 +99,7 @@ public class ProductController {
     }
 
     @PutMapping("/{productId}/status")
-    @Operation(summary = "상품 상태 변경")
+    @Operation(summary = "상품 상태 변경", description = "상품상태 코드 1: 판매중, 2:예약중, 3:거래완료")
     @ApiResponses(value = {@ApiResponse(responseCode = "200")})
     public DataResponseBody<ProductResponseDto> updateProductStatus(
         @AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -108,8 +108,6 @@ public class ProductController {
     ) {
         ProductResponseDto data = productService.changeStatus(userPrincipal, productId,
             request.getStatus());
-        DataResponseBody<ProductResponseDto> body = DataResponseBody.success(data);
-
         return DataResponseBody.success(data);
     }
 

--- a/src/main/java/org/mwt/market/domain/product/dto/ProductStatusUpdateRequestDto.java
+++ b/src/main/java/org/mwt/market/domain/product/dto/ProductStatusUpdateRequestDto.java
@@ -11,5 +11,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ProductStatusUpdateRequestDto {
 
-    private String status;
+    private Integer status;
 }

--- a/src/main/java/org/mwt/market/domain/product/entity/Product.java
+++ b/src/main/java/org/mwt/market/domain/product/entity/Product.java
@@ -96,8 +96,8 @@ public class Product {
         this.likes++;
     }
 
-    public void changeStatus(String status) {
-        this.status = ProductStatus.getFromDbIdx(Integer.parseInt(status));
+    public void changeStatus(Integer status) {
+        this.status = ProductStatus.getFromDbIdx(status);
     }
 
     public List<String> getImages() {

--- a/src/main/java/org/mwt/market/domain/product/entity/Product.java
+++ b/src/main/java/org/mwt/market/domain/product/entity/Product.java
@@ -97,7 +97,7 @@ public class Product {
     }
 
     public void changeStatus(String status) {
-        this.status = ProductStatus.getFromValue(status);
+        this.status = ProductStatus.getFromDbIdx(Integer.parseInt(status));
     }
 
     public List<String> getImages() {

--- a/src/main/java/org/mwt/market/domain/product/service/ProductService.java
+++ b/src/main/java/org/mwt/market/domain/product/service/ProductService.java
@@ -141,7 +141,7 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductResponseDto changeStatus(UserPrincipal userPrincipal, Long productId, String status) {
+    public ProductResponseDto changeStatus(UserPrincipal userPrincipal, Long productId, Integer status) {
         Product product = productRepository.findById(productId)
             .orElseThrow(NoSuchProductException::new);
         if (!userPrincipal.getEmail().equals(product.getSellerEmail())) {


### PR DESCRIPTION
product status의 변경 오류를 수정 하였습니다.
request는 의 status는 string타입인데, 메서드의 인덱스는 Integer 타입이라 발생하는 문제였습니다.

ProductStatusUpdateRequestDto의 status 타입을 Integer로 바꾸고 관련 코드를 수정하혔습니다.
swagger에 해당 코드를 명시 해두었습니다.

로컬테스트 완료